### PR TITLE
add keybase to readme & contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,8 @@ More information will be available on the [git workflow wiki page](https://githu
 
 You can also refer to Github's guide to [forking a repository](https://help.github.com/articles/fork-a-repo/) and to [syncing a fork](https://help.github.com/articles/syncing-a-fork/).
 
+If you have any questions or just want to chat, please join our team [fa_open_source](https://keybase.io/team/fa_open_source) on Keybase for community discussion. Keybase is a great platform for encrypted chat and file sharing.
+
 ## Other
 
 This contributing guide is based on the guidelines of the [SuperCollider contributing guide](https://raw.githubusercontent.com/supercollider/supercollider/develop/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ Please read our adopted [code of conduct](CODE_OF_CONDUCT.md) before contributin
 
 Read our [contributing guide](CONTRIBUTING.md) to learn about our development process, how to propose bugfixes and improvements.
 
+## Community
+If you have any questions or just want to chat, please join our team [fa_open_source](https://keybase.io/team/fa_open_source) on Keybase for community discussion. Keybase is a great platform for encrypted chat and file sharing.
+
 ## License
 
 TimeMap is distributed under the MIT License.


### PR DESCRIPTION
I've created an [open Keybase team](https://keybase.io/team/fa_open_source), meaning that anyone can join with write access, for community discussion and questions. @scztt @francamps please join and then promote the team on your profile with the command `keybase team settings fa_open_source --profile-promote=yes`.

I've added a link to README and CONTRIBUTING: do we need it anywhere else? Higher up in README, maybe?