### PR TITLE
Topic/add travis build 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 
 *service-account-key\.json
 src/config.js
+/yarn-error.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: node_js
+node_js:
+  - "stable"
+cache:
+  directories:
+    - node_modules
+before_script:
+  - npm install -g yarn
+  - cp ./src/config.example.js ./src/config.js
+install:
+  - yarn
+script:
+  - yarn build
+  - yarn lint
+  - yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
     - node_modules
 before_script:
   - npm install -g yarn
-  - cp ./src/config.example.js ./src/config.js
+  - cp ./src/example.config.js ./src/config.js
 install:
   - yarn
 script:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "npx babel src -d dist",
     "start": "node dist",
     "lint": "eslint src",
-    "test": "ava --watch"
+    "test-watch": "ava --watch",
+    "test": "ava --verbose"
   },
   "eslintConfig": {
     "extends": "eslint:recommended",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "nodemon -w src --exec \"babel-node src\"",
     "build": "npx babel src -d dist",
     "start": "node dist",
-    "lint": "standard \"src/**/*.js\"",
+    "lint": "standard \"src/**/*.js\" \"test/**/*/js\"",
     "test-watch": "ava --watch",
     "test": "ava --verbose"
   },

--- a/package.json
+++ b/package.json
@@ -7,24 +7,9 @@
     "dev": "nodemon -w src --exec \"babel-node src\"",
     "build": "npx babel src -d dist",
     "start": "node dist",
-    "lint": "eslint src",
+    "lint": "standard \"src/**/*.js\"",
     "test-watch": "ava --watch",
     "test": "ava --verbose"
-  },
-  "eslintConfig": {
-    "extends": "eslint:recommended",
-    "parserOptions": {
-      "ecmaVersion": 7,
-      "sourceType": "module"
-    },
-    "env": {
-      "node": true,
-      "es6": true
-    },
-    "rules": {
-      "no-console": 0,
-      "no-unused-vars": 1
-    }
   },
   "repository": {
     "type": "git",
@@ -54,8 +39,8 @@
     "@babel/preset-env": "^7.1.0",
     "@babel/register": "^7.0.0",
     "ava": "1.0.0-beta.8",
-    "eslint": "^3.1.1",
-    "nodemon": "^1.9.2"
+    "nodemon": "^1.9.2",
+    "standard": "^12.0.1"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
       "sourceType": "module"
     },
     "env": {
-      "node": true
+      "node": true,
+      "es6": true
     },
     "rules": {
       "no-console": 0,

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,22 +1,21 @@
-import {version} from "../../package.json";
-import {Router} from "express";
-import {idxSearcher} from "../lib/util";
+import { version } from '../../package.json'
+import { Router } from 'express'
 
-export default ({config, controller}) => {
-  let api = Router();
+export default ({ config, controller }) => {
+  let api = Router()
 
-  api.get("/", (req, res) => {
+  api.get('/', (req, res) => {
     res.json({
       version
-    });
-  });
+    })
+  })
 
-  api.get("/blueprints", (req, res) => {
-    res.json(controller.blueprints());
-  });
+  api.get('/blueprints', (req, res) => {
+    res.json(controller.blueprints())
+  })
 
-  api.get("/:source/:tab/:resource/:frag", (req, res) => {
-    const {source, tab, resource, frag} = req.params;
+  api.get('/:source/:tab/:resource/:frag', (req, res) => {
+    const { source, tab, resource, frag } = req.params
     controller
       .retrieveFrag(source, tab, resource, frag)
       .then(data => res.json(data))
@@ -24,10 +23,10 @@ export default ({config, controller}) => {
         res.json({
           error: err.message
         })
-      );
-  });
+      )
+  })
 
-  api.get("/:source/:tab/:resource", (req, res) => {
+  api.get('/:source/:tab/:resource', (req, res) => {
     controller
       .retrieve(req.params.source, req.params.tab, req.params.resource)
       .then(data => res.json(data))
@@ -35,10 +34,10 @@ export default ({config, controller}) => {
         res.json({
           error: err.message
         })
-      );
-  });
+      )
+  })
 
-  api.get("/update", (req, res) => {
+  api.get('/update', (req, res) => {
     controller
       .update()
       .then(msg =>
@@ -50,8 +49,8 @@ export default ({config, controller}) => {
         res.json({
           error: err.message
         })
-      );
-  });
+      )
+  })
 
-  return api;
-};
+  return api
+}

--- a/src/blueprinters/byColumn.js
+++ b/src/blueprinters/byColumn.js
@@ -1,5 +1,5 @@
-import R from "ramda";
-import {defaultBlueprint, defaultRoute} from "../lib/blueprinters";
+import R from 'ramda'
+import { defaultBlueprint, defaultRoute } from '../lib/blueprinters'
 
 /**
  * byColumn - generate a Blueprint from a data source by column. Each column
@@ -9,27 +9,27 @@ import {defaultBlueprint, defaultRoute} from "../lib/blueprinters";
  * @return {type} Blueprint
  * generated.
  */
-export default function byColumn(tabName, sourceName, sourceId, data) {
+export default function byColumn (tabName, sourceName, sourceId, data) {
   // Define Blueprint props
-  const bp = R.clone(defaultBlueprint);
+  const bp = R.clone(defaultBlueprint)
   bp.source = {
     name: sourceName,
     id: sourceId
-  };
-  bp.name = tabName;
+  }
+  bp.name = tabName
 
   // column names define routes
-  const labels = data[0];
+  const labels = data[0]
   labels.forEach(label => {
-    bp.routes[label] = R.clone(defaultRoute);
-  });
+    bp.routes[label] = R.clone(defaultRoute)
+  })
 
   // remaining rows as data
   data.forEach((row, idx) => {
-    if (idx == 0) return;
+    if (idx === 0) return
     labels.forEach((label, idx) => {
-      bp.routes[label].data.push(row[idx]);
-    });
-  });
-  return bp;
+      bp.routes[label].data.push(row[idx])
+    })
+  })
+  return bp
 }

--- a/src/blueprinters/byColumn.js
+++ b/src/blueprinters/byColumn.js
@@ -1,3 +1,4 @@
+import R from "ramda";
 import {defaultBlueprint, defaultRoute} from "../lib/blueprinters";
 
 /**

--- a/src/blueprinters/byGroup.js
+++ b/src/blueprinters/byGroup.js
@@ -1,6 +1,6 @@
-import R from "ramda";
-import {fmtObj, idxSearcher} from "../lib/util";
-import {defaultBlueprint, defaultRoute} from "../lib/blueprinters";
+import R from 'ramda'
+import { fmtObj } from '../lib/util'
+import { defaultBlueprint, defaultRoute } from '../lib/blueprinters'
 
 /**
  * byGroup - generate a Blueprint from a data source grouped by a column called 'group'
@@ -13,44 +13,44 @@ import {defaultBlueprint, defaultRoute} from "../lib/blueprinters";
  * @param  {type} name=""      name of blueprint.
  * @return {type} Blueprint
  */
-export default function byGroup(
+export default function byGroup (
   tabName,
   sourceName,
   sourceId,
   data,
-  label = "groups"
+  label = 'groups'
 ) {
   // Define Blueprint
-  const bp = R.clone(defaultBlueprint);
+  const bp = R.clone(defaultBlueprint)
   bp.source = {
     name: sourceName,
     id: sourceId
-  };
-  bp.name = tabName;
+  }
+  bp.name = tabName
 
   // Column names define routes
-  const itemLabels = data[0];
-  const fmt = fmtObj(itemLabels);
-  bp.routes[label] = R.clone(defaultRoute);
-  bp.routes[label].data = [];
+  const itemLabels = data[0]
+  const fmt = fmtObj(itemLabels)
+  bp.routes[label] = R.clone(defaultRoute)
+  bp.routes[label].data = []
 
-  const dataGroups = {};
+  const dataGroups = {}
 
   data.forEach((row, idx) => {
-    if (idx == 0) return;
-    const group = fmt(row).group;
+    if (idx === 0) return
+    const group = fmt(row).group
     if (!dataGroups[group]) {
-      dataGroups[group] = [fmt(row)];
+      dataGroups[group] = [fmt(row)]
     } else {
-      dataGroups[group].push(fmt(row));
+      dataGroups[group].push(fmt(row))
     }
-  });
+  })
   Object.keys(dataGroups).forEach(groupKey => {
     bp.routes[label].data.push({
       group: groupKey,
       group_label: dataGroups[groupKey][0].group_label,
       data: dataGroups[groupKey]
-    });
-  });
-  return bp;
+    })
+  })
+  return bp
 }

--- a/src/blueprinters/byId.js
+++ b/src/blueprinters/byId.js
@@ -1,6 +1,6 @@
-import R from "ramda";
-import {fmtObj, idxSearcher} from "../lib/util";
-import {defaultBlueprint, defaultRoute} from "../lib/blueprinters";
+import R from 'ramda'
+import { fmtObj } from '../lib/util'
+import { defaultBlueprint, defaultRoute } from '../lib/blueprinters'
 
 /**
  * byId - generate a Blueprint from a data source by id, which is an integer.
@@ -13,30 +13,30 @@ import {defaultBlueprint, defaultRoute} from "../lib/blueprinters";
  * @param  {type} name=""      name of blueprint.
  * @return {type} Blueprint
  */
-export default function byId(
+export default function byId (
   tabName,
   sourceName,
   sourceId,
   data,
-  label = "ids"
+  label = 'ids'
 ) {
   // Define Blueprint
-  const bp = R.clone(defaultBlueprint);
+  const bp = R.clone(defaultBlueprint)
   bp.source = {
     name: sourceName,
     id: sourceId
-  };
-  bp.name = tabName;
+  }
+  bp.name = tabName
 
   // Column names define routes
-  const itemLabels = data[0];
-  const fmt = fmtObj(itemLabels);
-  bp.routes[label] = R.clone(defaultRoute);
-  bp.routes[label].data = [];
+  const itemLabels = data[0]
+  const fmt = fmtObj(itemLabels)
+  bp.routes[label] = R.clone(defaultRoute)
+  bp.routes[label].data = []
 
   data.forEach((row, idx) => {
-    if (idx == 0) return;
-    bp.routes[label].data[fmt(row).id] = fmt(row);
-  });
-  return bp;
+    if (idx === 0) return
+    bp.routes[label].data[fmt(row).id] = fmt(row)
+  })
+  return bp
 }

--- a/src/blueprinters/byRow.js
+++ b/src/blueprinters/byRow.js
@@ -1,6 +1,6 @@
-import R from "ramda";
-import {fmtObj, idxSearcher} from "../lib/util";
-import {defaultBlueprint, defaultRoute} from "../lib/blueprinters";
+import R from 'ramda'
+import { fmtObj } from '../lib/util'
+import { defaultBlueprint, defaultRoute } from '../lib/blueprinters'
 
 /**
  * byRow - generate a Blueprint from a data source by row. The resource name
@@ -12,30 +12,30 @@ import {defaultBlueprint, defaultRoute} from "../lib/blueprinters";
  * @param  {type} name=""      name of blueprint.
  * @return {type} Blueprint
  */
-export default function byRow(
+export default function byRow (
   tabName,
   sourceName,
   sourceId,
   data,
-  label = "rows"
+  label = 'rows'
 ) {
   // Define Blueprint
-  const bp = R.clone(defaultBlueprint);
+  const bp = R.clone(defaultBlueprint)
   bp.source = {
     name: sourceName,
     id: sourceId
-  };
-  bp.name = tabName;
+  }
+  bp.name = tabName
 
   // Column names define routes
-  const itemLabels = data[0];
-  const fmt = fmtObj(itemLabels);
-  bp.routes[label] = R.clone(defaultRoute);
-  bp.routes[label].data = [];
+  const itemLabels = data[0]
+  const fmt = fmtObj(itemLabels)
+  bp.routes[label] = R.clone(defaultRoute)
+  bp.routes[label].data = []
 
   data.forEach((row, idx) => {
-    if (idx == 0) return;
-    bp.routes[label].data.push(fmt(row));
-  });
-  return bp;
+    if (idx === 0) return
+    bp.routes[label].data.push(fmt(row))
+  })
+  return bp
 }

--- a/src/blueprinters/byTree.js
+++ b/src/blueprinters/byTree.js
@@ -1,6 +1,5 @@
-import R from "ramda";
-import {fmtObj, idxSearcher} from "../lib/util";
-import {defaultBlueprint, defaultRoute} from "../lib/blueprinters";
+import R from 'ramda'
+import { defaultBlueprint, defaultRoute } from '../lib/blueprinters'
 
 /**
  * byTree - generate a Blueprint from a data source grouped by a column called 'group'
@@ -13,55 +12,56 @@ import {defaultBlueprint, defaultRoute} from "../lib/blueprinters";
  * @param  {type} name=""      name of blueprint.
  * @return {type} Blueprint
  */
-export default function byTree(
+export default function byTree (
   tabName,
   sourceName,
   sourceId,
   data,
-  label = "tree"
+  label = 'tree'
 ) {
   // Define Blueprint
-  const bp = R.clone(defaultBlueprint);
+  const bp = R.clone(defaultBlueprint)
   bp.source = {
     name: sourceName,
     id: sourceId
-  };
-  bp.name = tabName;
+  }
+  bp.name = tabName
 
   // Column names define routes
-  bp.routes[label] = R.clone(defaultRoute);
-  bp.routes[label].data = {};
+  bp.routes[label] = R.clone(defaultRoute)
+  bp.routes[label].data = {}
 
   const tree = {
-    key: "tags",
+    key: 'tags',
     children: {}
-  };
+  }
 
   data.forEach(path => {
-    const root = path[0];
-    if (!tree.children[root])
+    const root = path[0]
+    if (!tree.children[root]) {
       tree.children[root] = {
         key: root,
         children: {}
-      };
+      }
+    }
 
-    let depth = 1;
-    let parentNode = tree.children[root];
+    let depth = 1
+    let parentNode = tree.children[root]
 
     while (depth < path.length) {
-      const node = path[depth];
+      const node = path[depth]
       if (!parentNode.children[node]) {
         parentNode.children[node] = {
           key: node,
           children: {}
-        };
+        }
       }
-      parentNode = parentNode.children[node];
+      parentNode = parentNode.children[node]
 
-      depth++;
+      depth++
     }
-  });
+  })
 
-  bp.routes[label].data = tree;
-  return bp;
+  bp.routes[label].data = tree
+  return bp
 }

--- a/src/example.config.js
+++ b/src/example.config.js
@@ -1,18 +1,18 @@
-import BP from "./lib/blueprinters";
+import BP from './lib/blueprinters'
 
 export default {
   port: 4040,
   googleSheets: {
-    email: "project-name@reliable-baptist-23338.iam.gserviceaccount.com",
-    privateKey: "SOME_PRIVATE_KEY",
+    email: 'project-name@reliable-baptist-23338.iam.gserviceaccount.com',
+    privateKey: 'SOME_PRIVATE_KEY',
     sheets: [
       {
-        name: "example",
-        id: "1s-vfBR8Uy-B-TLO_C5Ozw4z-L0E3hdP8ohMV761ouRI",
+        name: 'example',
+        id: '1s-vfBR8Uy-B-TLO_C5Ozw4z-L0E3hdP8ohMV761ouRI',
         tabs: {
           objects: [BP.byRow]
         }
       }
     ]
   }
-};
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,12 @@
-import http from "http";
-import express from "express";
-import initialize from "./initialize";
-import middleware from "./middleware";
-import api from "./api";
-import config from "./config";
+import http from 'http'
+import express from 'express'
+import initialize from './initialize'
+import middleware from './middleware'
+import api from './api'
+import config from './config'
 
-let app = express();
-app.server = http.createServer(app);
+let app = express()
+app.server = http.createServer(app)
 
 initialize(controller => {
   app.use(
@@ -14,18 +14,18 @@ initialize(controller => {
       config,
       controller
     })
-  );
+  )
   app.use(
-    "/api",
+    '/api',
     api({
       config,
       controller
     })
-  );
+  )
 
   app.server.listen(process.env.PORT || config.port, () => {
-    console.log(`Started on port ${app.server.address().port}`);
-  });
-});
+    console.log(`Started on port ${app.server.address().port}`)
+  })
+})
 
-export default app;
+export default app

--- a/src/initialize.js
+++ b/src/initialize.js
@@ -1,16 +1,16 @@
-import StoreJson from "./models/StoreJson";
-import Fetcher from "./lib/Fetcher";
-import Controller from "./lib/Controller";
-import config from "./config";
+import StoreJson from './models/StoreJson'
+import Fetcher from './lib/Fetcher'
+import Controller from './lib/Controller'
+import config from './config'
 
-const {googleSheets} = config;
-const {sheets, privateKey, email} = googleSheets;
+const { googleSheets } = config
+const { sheets, privateKey, email } = googleSheets
 
-function authenticate(_fetcher) {
+function authenticate (_fetcher) {
   return _fetcher.fetcher.authenticate(email, privateKey).then(msg => {
-    console.log(msg);
-    return true;
-  });
+    console.log(msg)
+    return true
+  })
 }
 
 export default callback => {
@@ -18,29 +18,29 @@ export default callback => {
     return {
       name: sheet.name,
       fetcher: new Fetcher(new StoreJson(), sheet.name, sheet.id, sheet.tabs)
-    };
-  });
+    }
+  })
 
   Promise.all(fetchers.map(authenticate))
     .then(() => {
-      console.log(`===================`);
-      console.log(`grant access to: ${email}`);
-      console.log(`===================`);
+      console.log(`===================`)
+      console.log(`grant access to: ${email}`)
+      console.log(`===================`)
 
       // NB: reformat fetchers as config for controller
-      const config = {};
+      const config = {}
       fetchers.forEach(fetcher => {
-        config[fetcher.name] = fetcher.fetcher;
-      });
-      const controller = new Controller(config);
-      callback(controller);
+        config[fetcher.name] = fetcher.fetcher
+      })
+      const controller = new Controller(config)
+      callback(controller)
     })
     .catch(err => {
-      console.log(err);
+      console.log(err)
       console.log(
         `ERROR: the server couldn't connect to all of the sheets you provided. Ensure you have granted access to ${
           email
         } on ALL listed sheets.`
-      );
-    });
-};
+      )
+    })
+}

--- a/src/lib/Controller.js
+++ b/src/lib/Controller.js
@@ -8,8 +8,7 @@ class Controller {
   }
 
   sourceExists(source) {
-    return true;
-    if (Object.keys(this.fetchers).indexOf(source) == -1) return false;
+    return (Object.keys(this.fetchers).indexOf(source) >= 0)
   }
 
   blueprints() {

--- a/src/lib/Controller.js
+++ b/src/lib/Controller.js
@@ -3,51 +3,51 @@
  *
  */
 class Controller {
-  constructor(fetchers) {
-    this.fetchers = fetchers;
+  constructor (fetchers) {
+    this.fetchers = fetchers
   }
 
-  sourceExists(source) {
+  sourceExists (source) {
     return (Object.keys(this.fetchers).indexOf(source) >= 0)
   }
 
-  blueprints() {
+  blueprints () {
     return Object.keys(this.fetchers).map(
       source => this.fetchers[source].blueprints
-    );
+    )
   }
 
-  update() {
+  update () {
     return Promise.all(
       Object.keys(this.fetchers).map(source => {
-        return this.fetchers[source].update();
+        return this.fetchers[source].update()
       })
     ).then(results => {
-      return "All sources updated";
-    });
+      return 'All sources updated'
+    })
   }
 
-  retrieve(source, tab, resource) {
+  retrieve (source, tab, resource) {
     if (this.sourceExists(source)) {
-      const fetcher = this.fetchers[source];
-      return fetcher.retrieve(tab, resource);
+      const fetcher = this.fetchers[source]
+      return fetcher.retrieve(tab, resource)
     } else {
       return Promise.resolve().then(() => {
-        throw new Error(`Source ${source} not available.`);
-      });
+        throw new Error(`Source ${source} not available.`)
+      })
     }
   }
 
-  retrieveFrag(source, tab, resource, frag) {
+  retrieveFrag (source, tab, resource, frag) {
     if (this.sourceExists(source)) {
-      const fetcher = this.fetchers[source];
-      return fetcher.retrieveFrag(tab, resource, frag);
+      const fetcher = this.fetchers[source]
+      return fetcher.retrieveFrag(tab, resource, frag)
     } else {
       return Promise.resolve().then(() => {
-        throw new Error(`Source ${source} not available.`);
-      });
+        throw new Error(`Source ${source} not available.`)
+      })
     }
   }
 }
 
-export default Controller;
+export default Controller

--- a/src/lib/Fetcher.js
+++ b/src/lib/Fetcher.js
@@ -1,50 +1,49 @@
 // FetcherTwo class interfaces with Google Sheet, and saves to a specified db
-import {google} from "googleapis";
+import { google } from 'googleapis'
 import {
   fmtSourceTitle,
   fmtBlueprinterTitles,
-  deriveFilename,
   bp,
   isFunction
-} from "./util";
-import {byRow, byId} from "./blueprinters";
-import R from "ramda";
+} from './util'
+import { byRow } from './blueprinters'
+import R from 'ramda'
 
 class Fetcher {
-  constructor(db, sourceName, sourceId, blueprinters) {
+  constructor (db, sourceName, sourceId, blueprinters) {
     /*
      * The database that the fetcher should use. This should be an instance of a model-compliant class.
      * See models/Interface.js for the specifications for a model-compliant class.
      */
-    this.db = db;
+    this.db = db
 
     /*
-     * ID of the Google Sheet where the data is sourced. Note that the privateKey.client_email
+     * ID of the Google Sheet where the data is sourced. Note that the privateKey.clientEmail
      * loaded here must be added to the sheet as an editor.
      */
-    this.sourceId = sourceId;
+    this.sourceId = sourceId
 
     /*
      * The name of the source. This will prefix tabs saved in the database.
      */
-    this.sourceName = sourceName;
+    this.sourceName = sourceName
 
     /*
      * These are the available tabs for storing and retrieving data.
      * Each blueprinter is a function that returns a Blueprint from a
      * list of lists (which will be retrieved from gsheets).
      */
-    this.blueprinters = fmtBlueprinterTitles(blueprinters);
-    this.blueprints = {};
+    this.blueprinters = fmtBlueprinterTitles(blueprinters)
+    this.blueprints = {}
     Object.keys(this.blueprinters).forEach(key => {
-      this.blueprints[key] = null;
-    });
+      this.blueprints[key] = null
+    })
 
     /*
      * Google API setup
      */
-    this.sheets = google.sheets("v4");
-    this.auth = null;
+    this.sheets = google.sheets('v4')
+    this.auth = null
 
     /**
      * saveBp is a curried function that takes in a title and
@@ -57,35 +56,34 @@ class Fetcher {
         this.sourceName,
         this.sourceId,
         data
-      );
-      const blueprint = bp(saturatedBp); // TODO: come up with better semantics.
-      this.blueprints[title] = blueprint;
-      return this.db.save(saturatedBp);
-    });
+      )
+      const blueprint = bp(saturatedBp) // TODO: come up with better semantics.
+      this.blueprints[title] = blueprint
+      return this.db.save(saturatedBp)
+    })
   }
 
   /** returns a Promise that resolves if access is granted to the account, and rejects otherwise. */
-  authenticate(client_email, private_key) {
-    const googleAuth = new google.auth.JWT(client_email, null, private_key, [
-      "https://www.googleapis.com/auth/spreadsheets"
-    ]);
-    this.auth = googleAuth;
-    const {sourceId} = this;
+  authenticate (clientEmail, privateKey) {
+    const googleAuth = new google.auth.JWT(clientEmail, null, privateKey, [
+      'https://www.googleapis.com/auth/spreadsheets'
+    ])
+    this.auth = googleAuth
+    const { sourceId } = this
 
     return new Promise((resolve, reject) => {
-      googleAuth.authorize(function(err, tokens) {
+      googleAuth.authorize(function (err) {
         if (err) {
-          reject(err);
-          return;
+          reject(err)
         } else {
-          resolve(`Connected to ${sourceId}.`);
+          resolve(`Connected to ${sourceId}.`)
         }
-      });
-    });
+      })
+    })
   }
 
-  update() {
-    let tabTitles;
+  update () {
+    let tabTitles
     /* Retrieve all available routes on a given sheet, and store formatted copies of it where a formatter is available */
     return this.sheets.spreadsheets
       .get({
@@ -93,57 +91,57 @@ class Fetcher {
         spreadsheetId: this.sourceId
       })
       .then(response => {
-        tabTitles = response.data.sheets.map(sheet => sheet.properties.title);
+        tabTitles = response.data.sheets.map(sheet => sheet.properties.title)
         return this.sheets.spreadsheets.values.batchGet({
           auth: this.auth,
           spreadsheetId: this.sourceId,
           ranges: tabTitles
-        });
+        })
       })
       .then(results => {
-        const tabData = results.data.valueRanges;
+        const tabData = results.data.valueRanges
         return Promise.all(
           tabData.map((tab, idx) => {
-            const {values} = tab;
-            if (values == undefined) {
-              return Promise.resolve({});
+            const { values } = tab
+            if (values === undefined) {
+              return Promise.resolve({})
             }
-            const name = tabTitles[idx];
-            return this.save(name, values);
+            const name = tabTitles[idx]
+            return this.save(name, values)
           })
-        );
+        )
       })
-      .then(() => "All tabs updated");
+      .then(() => 'All tabs updated')
   }
 
-  save(tab, data) {
-    const title = fmtSourceTitle(tab);
+  save (tab, data) {
+    const title = fmtSourceTitle(tab)
     if (Object.keys(this.blueprinters).indexOf(title) > -1) {
-      const bpConfig = this.blueprinters[title];
+      const bpConfig = this.blueprinters[title]
 
       if (isFunction(bpConfig)) {
-        return this._saveBp(tab, title, data, bpConfig);
+        return this._saveBp(tab, title, data, bpConfig)
       } else {
-        return bpConfig.map(this._saveBp(tab, title, data));
+        return bpConfig.map(this._saveBp(tab, title, data))
       }
     } else {
       // If it can't find a blueprinter for the tab title, default to byRow
-      return this.db.save(byRow(tab, this.sourceName, this.sourceId, data));
+      return this.db.save(byRow(tab, this.sourceName, this.sourceId, data))
     }
   }
 
   // NB: could combine these functions by checking kwargs length
-  retrieve(tab, resource) {
-    const title = fmtSourceTitle(tab);
-    const url = `${this.sourceName}/${tab}/${resource}`;
-    return this.db.load(url, this.blueprints[title]);
+  retrieve (tab, resource) {
+    const title = fmtSourceTitle(tab)
+    const url = `${this.sourceName}/${tab}/${resource}`
+    return this.db.load(url, this.blueprints[title])
   }
 
-  retrieveFrag(tab, resource, frag) {
-    const title = fmtSourceTitle(tab);
-    const url = `${this.sourceName}/${tab}/${resource}/${frag}`;
-    return this.db.load(url, this.blueprints[title]);
+  retrieveFrag (tab, resource, frag) {
+    const title = fmtSourceTitle(tab)
+    const url = `${this.sourceName}/${tab}/${resource}/${frag}`
+    return this.db.load(url, this.blueprints[title])
   }
 }
 
-export default Fetcher;
+export default Fetcher

--- a/src/lib/blueprinters.js
+++ b/src/lib/blueprinters.js
@@ -1,33 +1,32 @@
-import path from "path";
-import fs from "fs";
+import path from 'path'
+import fs from 'fs'
 
 export const defaultBlueprint = {
   name: null,
   id: null,
-  dialects: ["rest"], // supported dialects, can (eventually) be multiple
+  dialects: ['rest'], // supported dialects, can (eventually) be multiple
   routes: {}
-};
+}
 
 export const defaultRoute = {
   options: {
     fragment: true
   },
   data: []
-};
+}
 
 // import all default exports from 'blueprinters' folder
-const allBps = {};
-const REL_PATH_TO_BPS = "../blueprinters";
-const normalizedPath = path.join(__dirname, REL_PATH_TO_BPS);
+const allBps = {}
+const REL_PATH_TO_BPS = '../blueprinters'
+const normalizedPath = path.join(__dirname, REL_PATH_TO_BPS)
 fs.readdirSync(normalizedPath).forEach(file => {
-  const bpName = file.replace(".js", "");
-  allBps[bpName] = require(`${REL_PATH_TO_BPS}/${file}`).default;
-});
+  const bpName = file.replace('.js', '')
+  allBps[bpName] = require(`${REL_PATH_TO_BPS}/${file}`).default
+})
 
 // NB: revert to ES5 'module.exports' required to make blueprinters from
 // each file in blueprinters folder available for granular import from here.
-module.exports = {
+module.exports = Object.assign({
   defaultBlueprint,
-  defaultRoute,
-  ...allBps
-}
+  defaultRoute
+}, allBps)

--- a/src/lib/blueprinters.js
+++ b/src/lib/blueprinters.js
@@ -25,4 +25,7 @@ fs.readdirSync(normalizedPath).forEach(file => {
   allBps[bpName] = require(`${REL_PATH_TO_BPS}/${file}`).default;
 });
 
-module.exports = allBps;
+module.exports = Object.assign({
+  "defaultBlueprint": defaultBlueprint,
+  "defaultRoute": defaultRoute
+}, allBps);

--- a/src/lib/blueprinters.js
+++ b/src/lib/blueprinters.js
@@ -1,9 +1,6 @@
 import path from "path";
 import fs from "fs";
 
-const REL_PATH_TO_BPS = "../blueprinters";
-const allBps = {};
-
 export const defaultBlueprint = {
   name: null,
   id: null,
@@ -19,13 +16,18 @@ export const defaultRoute = {
 };
 
 // import all default exports from 'blueprinters' folder
+const allBps = {};
+const REL_PATH_TO_BPS = "../blueprinters";
 const normalizedPath = path.join(__dirname, REL_PATH_TO_BPS);
 fs.readdirSync(normalizedPath).forEach(file => {
   const bpName = file.replace(".js", "");
   allBps[bpName] = require(`${REL_PATH_TO_BPS}/${file}`).default;
 });
 
-module.exports = Object.assign({
-  "defaultBlueprint": defaultBlueprint,
-  "defaultRoute": defaultRoute
-}, allBps);
+// NB: revert to ES5 'module.exports' required to make blueprinters from
+// each file in blueprinters folder available for granular import from here.
+module.exports = {
+  defaultBlueprint,
+  defaultRoute,
+  ...allBps
+}

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,16 +1,17 @@
-import R from "ramda";
+import R from 'ramda'
 
-String.prototype.replaceAll = function(search, replacement) {
-  const target = this;
-  return target.replace(new RegExp(search, "g"), replacement);
-};
+/* eslint-disable */
+String.prototype.replaceAll = function (search, replacement) {
+  const target = this
+  return target.replace(new RegExp(search, 'g'), replacement)
+}
+/* eslint-enable */
 
-function camelize(str) {
-  return str.replace(/(?:^\w|[A-Z]|\b\w|\s+)/g, function(match, index) {
-    if (+match === 0) return ""; // or if (/\s+/.test(match)) for white spaces
-    // return index == 0 ? match.toLowerCase() : match.toUpperCase();
-    return match.toUpperCase();
-  });
+function camelize (str) {
+  return str.replace(/(?:^\w|[A-Z]|\b\w|\s+)/g, function (match) {
+    if (+match === 0) return '' // or if (/\s+/.test(match)) for white spaces
+    return match.toUpperCase()
+  })
 }
 
 export const fmtObj = R.curry(
@@ -23,71 +24,71 @@ export const fmtObj = R.curry(
       camelCaseKeys: false
     }
   ) => {
-    const obj = {};
+    const obj = {}
     const fmtColName = colName => {
       if (options.camelCaseKeys) {
-        return camelize(colName);
+        return camelize(colName)
       } else if (options.hyphenatedKeys) {
-        return colName.toLowerCase().replaceAll(" ", "-");
+        return colName.toLowerCase().replaceAll(' ', '-')
       } else if (options.noSpacesInKeys) {
-        return colName.replaceAll(" ", "");
+        return colName.replaceAll(' ', '')
       } else {
-        return colName;
+        return colName
       }
-    };
+    }
     columnNames.forEach((columnName, idx) => {
-      obj[fmtColName(columnName)] = row[idx];
-    });
-    return obj;
+      obj[fmtColName(columnName)] = row[idx]
+    })
+    return obj
   }
-);
+)
 
 /* search for object with key in array. Return index if exists, or -1 if not */
 export const idxSearcher = R.curry((attrName, searchValue, myArray) => {
   for (var i = 0; i < myArray.length; i++) {
-    if (myArray[i][attrName] == searchValue) {
-      return i;
+    if (myArray[i][attrName] === searchValue) {
+      return i
     }
   }
-  return -1;
-});
+  return -1
+})
 
 /* more site specific functions. TODO: maybe move to another folder? */
 
-export function fmtSourceTitle(name) {
-  return name.replaceAll(" ", "-").toLowerCase();
+export function fmtSourceTitle (name) {
+  return name.replaceAll(' ', '-').toLowerCase()
 }
 
-export function fmtBlueprinterTitles(tabs) {
-  const obj = {};
+export function fmtBlueprinterTitles (tabs) {
+  const obj = {}
   Object.keys(tabs).forEach(tab => {
-    const name = fmtSourceTitle(tab);
-    obj[name] = tabs[tab];
-  });
-  return obj;
+    const name = fmtSourceTitle(tab)
+    obj[name] = tabs[tab]
+  })
+  return obj
 }
 
-export function deriveFilename(source, tab) {
-  return `${fmtSourceTitle(source)}-${fmtSourceTitle(tab)}.json`;
+export function deriveFilename (source, tab) {
+  return `${fmtSourceTitle(source)}-${fmtSourceTitle(tab)}.json`
 }
 
-export function bp(full) {
+export function bp (full) {
   const blueprint = {
     name: R.clone(full.name),
     source: R.clone(full.source),
     dialects: R.clone(full.dialects),
     routes: {}
-  };
+  }
   Object.keys(full.routes).forEach(route => {
     blueprint.routes[route] = {
       options: R.clone(full.routes[route].options)
-    };
-  });
-  return blueprint;
+    }
+  })
+  return blueprint
 }
 
-export function isFunction(functionToCheck) {
+export function isFunction (functionToCheck) {
   return (
-    functionToCheck && {}.toString.call(functionToCheck) === "[object Function]"
-  );
+    functionToCheck && {}.toString.call(functionToCheck) === '[object Function]'
+  )
 }

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -1,17 +1,18 @@
-import {Router, next} from "express";
-import {mapboxAccessToken} from "../config";
-import morgan from "morgan";
-import mapbox from "./mapbox";
+import { Router } from 'express'
+import { mapboxAccessToken } from '../config'
+import morgan from 'morgan'
+import mapbox from './mapbox'
 
-export default ({config, db}) => {
-  let routes = Router();
+// eslint-disable-next-line
+export default ({ config, db }) => {
+  let routes = Router()
 
   /* logging middleware */
-  routes.use(morgan("dev"));
+  routes.use(morgan('dev'))
 
   if (mapboxAccessToken) {
-    routes.get("/mapbox/:z/:y/:x", mapbox(mapboxAccessToken));
+    routes.get('/mapbox/:z/:y/:x', mapbox(mapboxAccessToken))
   }
 
-  return routes;
-};
+  return routes
+}

--- a/src/middleware/mapbox/index.js
+++ b/src/middleware/mapbox/index.js
@@ -1,16 +1,14 @@
-import fetch from "node-fetch";
-import fs from "fs";
-// TODO: load images from mapbox API and store.
+import fetch from 'node-fetch'
 
-const baseUrl = "http://a.tiles.mapbox.com/v4/mapbox.satellite";
+const baseUrl = 'http://a.tiles.mapbox.com/v4/mapbox.satellite'
 export default accessToken => (req, res) => {
-  const {x, y, z} = req.params;
+  const { x, y, z } = req.params
   // const filename = `${z}-${y}-${x}.png`
   // const fileStream = fs.createWriteStream(`${z}-${y}-${x}.png`)
   fetch(
-    `http://a.tiles.mapbox.com/v4/mapbox.satellite/${z}/${y}/${x}@2x.png?access_token=${accessToken}`
+    `${baseUrl}/${z}/${y}/${x}@2x.png?access_token=${accessToken}`
   ).then(result => {
-    res.set("Content-Type", "image/png");
-    result.body.pipe(res);
-  });
-};
+    res.set('Content-Type', 'image/png')
+    result.body.pipe(res)
+  })
+}

--- a/src/models/Interface.js
+++ b/src/models/Interface.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 /**
  * Model is a class whose sole responsibility is to save and load blueprints.
  * It allows for different storage mechanisms for different kinds of blueprints.
@@ -9,7 +10,7 @@ class Model {
    * @param  {type} blueprint the Blueprint to be saved.
    * @return {type} Promise   which returns True.
    */
-  save(blueprint) {}
+  save (blueprint) {}
 
   /**
    * load - load a resource from a data model, using a Blueprint object as
@@ -19,5 +20,5 @@ class Model {
    * @param  {type} blueprint Blueprint object (desaturated?).
    * @return {type}           Object containing the resource data.
    */
-  load(url, blueprint) {}
+  load (url, blueprint) {}
 }

--- a/src/models/StoreJson.js
+++ b/src/models/StoreJson.js
@@ -1,12 +1,10 @@
-import fs from "mz/fs";
-import hash from "object-hash";
-import {fmtSourceTitle} from "../lib/util";
-import path from "path";
+import fs from 'mz/fs'
+import { fmtSourceTitle } from '../lib/util'
 
-const STORAGE_DIRNAME = "temp";
+const STORAGE_DIRNAME = 'temp'
 
 class StoreJson {
-  save(bp) {
+  save (bp) {
     return Promise.all(
       Object.keys(bp.routes).map(route =>
         fs.writeFile(
@@ -16,50 +14,50 @@ class StoreJson {
           JSON.stringify(bp.routes[route].data)
         )
       )
-    );
+    )
   }
 
-  load(url, bp) {
-    const parts = url.split("/");
+  load (url) {
+    const parts = url.split('/')
     const fname = `${STORAGE_DIRNAME}/${parts[0]}__${parts[1]}__${
       parts[2]
-    }.json`;
+    }.json`
     return fs
       .exists(fname)
       .then(isAvailable => {
-        if (isAvailable) return fs.readFile(fname, "utf8");
+        if (isAvailable) return fs.readFile(fname, 'utf8')
         else {
-          throw new Error("No resource exists");
+          throw new Error('No resource exists')
         }
       })
       .then(data => JSON.parse(data))
       .then(data => {
         if (parts.length === 3) {
           // No lookup if the requested url doesn't have a fragment
-          return data;
-        } else if (parts[2] === "ids") {
+          return data
+        } else if (parts[2] === 'ids') {
           // Do a lookup if fragment is included to filter a relevant item
           // When the resource requested is 'ids'
-          const id = parseInt(parts[3]);
+          const id = parseInt(parts[3])
           if (!isNaN(id) && id >= 0 && id < data.length) {
-            return data[id];
+            return data[id]
           } else {
-            throw new Error(`Fragment index does not exist`);
+            throw new Error(`Fragment index does not exist`)
           }
         } else {
           // Do a lookup if fragment is included to filter a relevant item
-          const index = parseInt(parts[3]);
+          const index = parseInt(parts[3])
           if (!isNaN(index) && index >= 0 && index < data.length) {
-            console.log(data, index);
-            return data.filter((vl, idx) => idx === index)[0];
+            console.log(data, index)
+            return data.filter((vl, idx) => idx === index)[0]
           } else {
-            throw new Error(`Fragment index does not exist`);
+            throw new Error(`Fragment index does not exist`)
           }
         }
-      });
+      })
   }
 
   // TODO: add method to build blueprint from data source
 }
 
-export default StoreJson;
+export default StoreJson

--- a/src/models/StoreJson.js
+++ b/src/models/StoreJson.js
@@ -41,7 +41,7 @@ class StoreJson {
           // Do a lookup if fragment is included to filter a relevant item
           // When the resource requested is 'ids'
           const id = parseInt(parts[3]);
-          if (id !== NaN && id >= 0 && id < data.length) {
+          if (!isNaN(id) && id >= 0 && id < data.length) {
             return data[id];
           } else {
             throw new Error(`Fragment index does not exist`);
@@ -49,7 +49,7 @@ class StoreJson {
         } else {
           // Do a lookup if fragment is included to filter a relevant item
           const index = parseInt(parts[3]);
-          if (index !== NaN && index >= 0 && index < data.length) {
+          if (!isNaN(index) && index >= 0 && index < data.length) {
             console.log(data, index);
             return data.filter((vl, idx) => idx === index)[0];
           } else {

--- a/test/internals.js
+++ b/test/internals.js
@@ -17,19 +17,19 @@ test('defaultBlueprint exports', t => {
   const expected = {
     name: null,
     id: null,
-    dialects: ["rest"],
+    dialects: ['rest'],
     routes: {}
   }
   t.deepEqual(expected, defaultBlueprint)
 })
 
 test('byColumn blueprinter generates expected output', t => {
-  const actual = byColumn("eg ColumnBlueprint", "egSourceName", "egSourceId", egInput1)
+  const actual = byColumn('eg ColumnBlueprint', 'egSourceName', 'egSourceId', egInput1)
   const expected = R.clone(defaultBlueprint)
-  expected.name = "eg ColumnBlueprint"
+  expected.name = 'eg ColumnBlueprint'
   expected.source = {
-    id: "egSourceId",
-    name: "egSourceName"
+    id: 'egSourceId',
+    name: 'egSourceName'
   }
   expected.routes['h1'] = R.clone(defaultRoute)
   expected.routes['h1'].data = [1, 4]
@@ -41,24 +41,23 @@ test('byColumn blueprinter generates expected output', t => {
 })
 
 test('byRow blueprinter generates expected output', t => {
-  const actual = byRow("egRowBlueprint", "egSourceName", "egSourceId", egInput1, "items", )
+  const actual = byRow('egRowBlueprint', 'egSourceName', 'egSourceId', egInput1, 'items')
   const expected = R.clone(defaultBlueprint)
-  expected.name = "egRowBlueprint"
+  expected.name = 'egRowBlueprint'
   expected.source = {
-    id: "egSourceId",
-    name: "egSourceName"
+    id: 'egSourceId',
+    name: 'egSourceName'
   }
   expected.routes['items'] = R.clone(defaultRoute)
   expected.routes['items'].data = [{
-      h1: 1,
-      h2: 2,
-      h3: 3
-    },
-    {
-      h1: 4,
-      h2: 5,
-      h3: 6
-    },
-  ]
+    h1: 1,
+    h2: 2,
+    h3: 3
+  },
+  {
+    h1: 4,
+    h2: 5,
+    h3: 6
+  }]
   t.deepEqual(expected, actual)
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -613,30 +613,26 @@ accepts@^1.3.0, accepts@~1.3.5:
     mime-types "~2.1.18"
     negotiator "0.6.1"
 
-acorn-jsx@^3.0.0:
-  version "3.0.1"
-  resolved "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
+acorn-jsx@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.0.tgz#958584ddb60990c02c97c1bd9d521fce433bb101"
+
+acorn@^6.0.2:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.4.tgz#77377e7353b72ec5104550aa2d2097a2fd40b754"
+
+ajv-keywords@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
+
+ajv@^6.0.1, ajv@^6.5.0:
+  version "6.5.5"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.5.tgz#cf97cdade71c6399a92c6d6c4177381291b781a1"
   dependencies:
-    acorn "^3.0.4"
-
-acorn@^3.0.4:
-  version "3.3.0"
-  resolved "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
-
-acorn@^5.5.0:
-  version "5.7.3"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
-
-ajv-keywords@^1.0.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.5.1.tgz#314dd0a4b3368fad3dfcdc54ede6171b886daf3c"
-
-ajv@^4.7.0:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
-  dependencies:
-    co "^4.6.0"
-    json-stable-stringify "^1.0.1"
+    fast-deep-equal "^2.0.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
 
 ansi-align@^2.0.0:
   version "2.0.0"
@@ -644,11 +640,7 @@ ansi-align@^2.0.0:
   dependencies:
     string-width "^2.0.0"
 
-ansi-escapes@^1.1.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
-
-ansi-escapes@^3.1.0:
+ansi-escapes@^3.0.0, ansi-escapes@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
 
@@ -721,6 +713,13 @@ array-find-index@^1.0.1:
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
+
+array-includes@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.0.3.tgz#184b48f62d92d7452bb31b323165c7f8bd02266d"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.7.0"
 
 array-union@^1.0.1:
   version "1.0.2"
@@ -847,7 +846,7 @@ axios@^0.18.0:
     follow-redirects "^1.3.0"
     is-buffer "^1.1.5"
 
-babel-code-frame@^6.16.0:
+babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
   dependencies:
@@ -1027,7 +1026,7 @@ capture-stack-trace@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz#a6c0bbe1f38f3aa0b92238ecb6ff42c344d4135d"
 
-chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@^1.1.3:
   version "1.1.3"
   resolved "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -1037,13 +1036,17 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.1, chalk@^2.4.1:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chardet@^0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
 
 chokidar@^2.0.2, chokidar@^2.0.3, chokidar@^2.0.4:
   version "2.0.4"
@@ -1101,12 +1104,6 @@ cli-boxes@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
 
-cli-cursor@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
-  dependencies:
-    restore-cursor "^1.0.1"
-
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
@@ -1131,10 +1128,6 @@ cli-width@^2.0.0:
 clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
-
-co@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
 
 code-excerpt@^2.1.1:
   version "2.1.1"
@@ -1201,15 +1194,6 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.5.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
-  dependencies:
-    buffer-from "^1.0.0"
-    inherits "^2.0.3"
-    readable-stream "^2.2.2"
-    typedarray "^0.0.6"
-
 concordance@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/concordance/-/concordance-3.0.0.tgz#b2286af54405fc995fc7345b0b106d8dd073cb29"
@@ -1240,6 +1224,10 @@ configstore@^3.0.0:
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
+
+contains-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
 
 content-disposition@0.5.2:
   version "0.5.2"
@@ -1300,6 +1288,16 @@ cross-spawn@^5.0.1:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
+cross-spawn@^6.0.5:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
+  dependencies:
+    nice-try "^1.0.4"
+    path-key "^2.0.1"
+    semver "^5.5.0"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
@@ -1310,19 +1308,17 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-d@1:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
-  dependencies:
-    es5-ext "^0.10.9"
-
 date-time@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/date-time/-/date-time-2.1.0.tgz#0286d1b4c769633b3ca13e1e62558d2dbdc2eba2"
   dependencies:
     time-zone "^1.0.0"
 
-debug@2.6.9, debug@^2.1.1, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3:
+debug-log@^1.0.0:
+  version "1.0.1"
+  resolved "http://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
+
+debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -1373,6 +1369,12 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
+define-properties@^1.1.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  dependencies:
+    object-keys "^1.0.12"
+
 define-property@^0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
@@ -1391,6 +1393,17 @@ define-property@^2.0.2:
   dependencies:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
+
+deglob@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/deglob/-/deglob-2.1.1.tgz#d268e168727799862e8eac07042e165957c1f3be"
+  dependencies:
+    find-root "^1.0.0"
+    glob "^7.0.5"
+    ignore "^3.0.9"
+    pkg-config "^1.1.0"
+    run-parallel "^1.1.2"
+    uniq "^1.0.1"
 
 del@^2.0.2:
   version "2.2.2"
@@ -1438,7 +1451,14 @@ dir-glob@^2.0.0:
     arrify "^1.0.1"
     path-type "^3.0.0"
 
-doctrine@^2.0.0:
+doctrine@1.5.0:
+  version "1.5.0"
+  resolved "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
+
+doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   dependencies:
@@ -1491,68 +1511,33 @@ equal-length@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/equal-length/-/equal-length-1.0.1.tgz#21ca112d48ab24b4e1e7ffc0e5339d31fdfc274c"
 
-error-ex@^1.3.1:
+error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   dependencies:
     is-arrayish "^0.2.1"
 
-es5-ext@^0.10.14, es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
-  version "0.10.46"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.46.tgz#efd99f67c5a7ec789baa3daa7f79870388f7f572"
+es-abstract@^1.7.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.12.0.tgz#9dbbdd27c6856f0001421ca18782d786bf8a6165"
   dependencies:
-    es6-iterator "~2.0.3"
-    es6-symbol "~3.1.1"
-    next-tick "1"
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
+es-to-primitive@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz#edf72478033456e8dda8ef09e00ad9650707f377"
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
 
 es6-error@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
-
-es6-iterator@^2.0.1, es6-iterator@~2.0.1, es6-iterator@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
-  dependencies:
-    d "1"
-    es5-ext "^0.10.35"
-    es6-symbol "^3.1.1"
-
-es6-map@^0.1.3:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/es6-map/-/es6-map-0.1.5.tgz#9136e0503dcc06a301690f0bb14ff4e364e949f0"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-    es6-iterator "~2.0.1"
-    es6-set "~0.1.5"
-    es6-symbol "~3.1.1"
-    event-emitter "~0.3.5"
-
-es6-set@~0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/es6-set/-/es6-set-0.1.5.tgz#d2b3ec5d4d800ced818db538d28974db0a73ccb1"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-    es6-iterator "~2.0.1"
-    es6-symbol "3.1.1"
-    event-emitter "~0.3.5"
-
-es6-symbol@3.1.1, es6-symbol@^3.1.1, es6-symbol@~3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
-
-es6-weak-map@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.2.tgz#5e3ab32251ffd1538a1f8e5ffa1357772f92d96f"
-  dependencies:
-    d "1"
-    es5-ext "^0.10.14"
-    es6-iterator "^2.0.1"
-    es6-symbol "^3.1.1"
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -1562,54 +1547,136 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.4, escape-string-regexp@^
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
-escope@^3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/escope/-/escope-3.6.0.tgz#e01975e812781a163a6dadfdd80398dc64c889c3"
+eslint-config-standard-jsx@6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard-jsx/-/eslint-config-standard-jsx-6.0.2.tgz#90c9aa16ac2c4f8970c13fc7efc608bacd02da70"
+
+eslint-config-standard@12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-12.0.0.tgz#638b4c65db0bd5a41319f96bba1f15ddad2107d9"
+
+eslint-import-resolver-node@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"
   dependencies:
-    es6-map "^0.1.3"
-    es6-weak-map "^2.0.1"
+    debug "^2.6.9"
+    resolve "^1.5.0"
+
+eslint-module-utils@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz#b270362cd88b1a48ad308976ce7fa54e98411746"
+  dependencies:
+    debug "^2.6.8"
+    pkg-dir "^1.0.0"
+
+eslint-plugin-es@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-1.3.2.tgz#6d2e94ed40db3b3d92a0eb55c7c06e3a7adbb3db"
+  dependencies:
+    eslint-utils "^1.3.0"
+    regexpp "^2.0.1"
+
+eslint-plugin-import@~2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz#6b17626d2e3e6ad52cfce8807a845d15e22111a8"
+  dependencies:
+    contains-path "^0.1.0"
+    debug "^2.6.8"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.3.1"
+    eslint-module-utils "^2.2.0"
+    has "^1.0.1"
+    lodash "^4.17.4"
+    minimatch "^3.0.3"
+    read-pkg-up "^2.0.0"
+    resolve "^1.6.0"
+
+eslint-plugin-node@~7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-7.0.1.tgz#a6e054e50199b2edd85518b89b4e7b323c9f36db"
+  dependencies:
+    eslint-plugin-es "^1.3.1"
+    eslint-utils "^1.3.1"
+    ignore "^4.0.2"
+    minimatch "^3.0.4"
+    resolve "^1.8.1"
+    semver "^5.5.0"
+
+eslint-plugin-promise@~4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.0.1.tgz#2d074b653f35a23d1ba89d8e976a985117d1c6a2"
+
+eslint-plugin-react@~7.11.1:
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.11.1.tgz#c01a7af6f17519457d6116aa94fc6d2ccad5443c"
+  dependencies:
+    array-includes "^3.0.3"
+    doctrine "^2.1.0"
+    has "^1.0.3"
+    jsx-ast-utils "^2.0.1"
+    prop-types "^15.6.2"
+
+eslint-plugin-standard@~4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-4.0.0.tgz#f845b45109c99cd90e77796940a344546c8f6b5c"
+
+eslint-scope@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"
+  dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint@^3.1.1:
-  version "3.19.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
+eslint-utils@^1.3.0, eslint-utils@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.3.1.tgz#9a851ba89ee7c460346f97cf8939c7298827e512"
+
+eslint-visitor-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
+
+eslint@~5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.4.0.tgz#d068ec03006bb9e06b429dc85f7e46c1b69fac62"
   dependencies:
-    babel-code-frame "^6.16.0"
-    chalk "^1.1.3"
-    concat-stream "^1.5.2"
-    debug "^2.1.1"
-    doctrine "^2.0.0"
-    escope "^3.6.0"
-    espree "^3.4.0"
-    esquery "^1.0.0"
-    estraverse "^4.2.0"
+    ajv "^6.5.0"
+    babel-code-frame "^6.26.0"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^3.1.0"
+    doctrine "^2.1.0"
+    eslint-scope "^4.0.0"
+    eslint-utils "^1.3.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^4.0.0"
+    esquery "^1.0.1"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
-    glob "^7.0.3"
-    globals "^9.14.0"
-    ignore "^3.2.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.7.0"
+    ignore "^4.0.2"
     imurmurhash "^0.1.4"
-    inquirer "^0.12.0"
-    is-my-json-valid "^2.10.0"
-    is-resolvable "^1.0.0"
-    js-yaml "^3.5.1"
-    json-stable-stringify "^1.0.0"
+    inquirer "^5.2.0"
+    is-resolvable "^1.1.0"
+    js-yaml "^3.11.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
-    lodash "^4.0.0"
-    mkdirp "^0.5.0"
+    lodash "^4.17.5"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     optionator "^0.8.2"
-    path-is-inside "^1.0.1"
-    pluralize "^1.2.1"
-    progress "^1.1.8"
-    require-uncached "^1.0.2"
-    shelljs "^0.7.5"
-    strip-bom "^3.0.0"
-    strip-json-comments "~2.0.1"
-    table "^3.7.8"
-    text-table "~0.2.0"
-    user-home "^2.0.0"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    regexpp "^2.0.0"
+    require-uncached "^1.0.3"
+    semver "^5.5.0"
+    strip-ansi "^4.0.0"
+    strip-json-comments "^2.0.1"
+    table "^4.0.3"
+    text-table "^0.2.0"
 
 esm@^3.0.80:
   version "3.0.84"
@@ -1624,12 +1691,13 @@ espower-location-detector@^1.0.0:
     source-map "^0.5.0"
     xtend "^4.0.0"
 
-espree@^3.4.0:
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
+espree@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-4.1.0.tgz#728d5451e0fd156c04384a7ad89ed51ff54eb25f"
   dependencies:
-    acorn "^5.5.0"
-    acorn-jsx "^3.0.0"
+    acorn "^6.0.2"
+    acorn-jsx "^5.0.0"
+    eslint-visitor-keys "^1.0.0"
 
 esprima@^4.0.0:
   version "4.0.1"
@@ -1641,7 +1709,7 @@ espurify@^1.6.0:
   dependencies:
     core-js "^2.0.0"
 
-esquery@^1.0.0:
+esquery@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.0.1.tgz#406c51658b1f5991a5f9b62b1dc25b00e3e5c708"
   dependencies:
@@ -1653,7 +1721,7 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
 
-estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
@@ -1664,13 +1732,6 @@ esutils@^2.0.2:
 etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
-
-event-emitter@~0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
 
 event-stream@~3.3.0:
   version "3.3.6"
@@ -1696,10 +1757,6 @@ execa@^0.7.0:
     p-finally "^1.0.0"
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
-
-exit-hook@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
 
 expand-brackets@^2.1.4:
   version "2.1.4"
@@ -1774,6 +1831,14 @@ extend@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
+external-editor@^2.1.0:
+  version "2.2.0"
+  resolved "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
+  dependencies:
+    chardet "^0.4.0"
+    iconv-lite "^0.4.17"
+    tmp "^0.0.33"
+
 extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
@@ -1787,20 +1852,21 @@ extglob@^2.0.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+
 fast-diff@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
 
+fast-json-stable-stringify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
+
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
-
-figures@^1.3.5:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
-  dependencies:
-    escape-string-regexp "^1.0.5"
-    object-assign "^4.1.0"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -1843,6 +1909,17 @@ find-cache-dir@^1.0.0:
     commondir "^1.0.1"
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
+
+find-root@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+
+find-up@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
+  dependencies:
+    path-exists "^2.0.0"
+    pinkie-promise "^2.0.0"
 
 find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
@@ -1912,9 +1989,17 @@ fsevents@^1.2.2:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
 
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+
 function-name-support@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/function-name-support/-/function-name-support-0.2.0.tgz#55d3bfaa6eafd505a50f9bc81fdf57564a0bb071"
+
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -1937,21 +2022,13 @@ gcp-metadata@^0.6.3:
     extend "^3.0.1"
     retry-axios "0.3.2"
 
-generate-function@^2.0.0:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/generate-function/-/generate-function-2.3.1.tgz#f069617690c10c868e73b8465746764f97c3479f"
-  dependencies:
-    is-property "^1.0.2"
-
-generate-object-property@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/generate-object-property/-/generate-object-property-1.2.0.tgz#9c0e1c40308ce804f4783618b937fa88f99d50d0"
-  dependencies:
-    is-property "^1.0.0"
-
 get-port@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-4.0.0.tgz#373c85960138ee20027c070e3cb08019fea29816"
+
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
 
 get-stream@^3.0.0:
   version "3.0.0"
@@ -1989,9 +2066,9 @@ globals@^11.1.0:
   version "11.8.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.8.0.tgz#c1ef45ee9bed6badf0663c5cb90e8d1adec1321d"
 
-globals@^9.14.0:
-  version "9.18.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
+globals@^11.7.0:
+  version "11.9.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.9.0.tgz#bde236808e987f290768a93d065060d78e6ab249"
 
 globby@^5.0.0:
   version "5.0.0"
@@ -2100,6 +2177,10 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
 
+has-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.0.tgz#ba1a8f1af2a0fc39650f5c850367704122063b44"
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -2130,6 +2211,12 @@ has-values@^1.0.0:
   dependencies:
     is-number "^3.0.0"
     kind-of "^4.0.0"
+
+has@^1.0.1, has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  dependencies:
+    function-bind "^1.1.1"
 
 home-or-tmp@^3.0.0:
   version "3.0.0"
@@ -2170,7 +2257,7 @@ iconv-lite@0.4.23:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.4.4:
+iconv-lite@^0.4.17, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   dependencies:
@@ -2186,9 +2273,13 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
-ignore@^3.2.0, ignore@^3.3.5:
+ignore@^3.0.9, ignore@^3.3.5:
   version "3.3.10"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+
+ignore@^4.0.2:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
 
 import-lazy@^2.1.0:
   version "2.1.0"
@@ -2216,7 +2307,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
+inherits@2, inherits@2.0.3, inherits@^2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -2224,27 +2315,23 @@ ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
-inquirer@^0.12.0:
-  version "0.12.0"
-  resolved "http://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz#1ef2bfd63504df0bc75785fff8c2c41df12f077e"
+inquirer@^5.2.0:
+  version "5.2.0"
+  resolved "http://registry.npmjs.org/inquirer/-/inquirer-5.2.0.tgz#db350c2b73daca77ff1243962e9f22f099685726"
   dependencies:
-    ansi-escapes "^1.1.0"
-    ansi-regex "^2.0.0"
-    chalk "^1.0.0"
-    cli-cursor "^1.0.1"
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
     cli-width "^2.0.0"
-    figures "^1.3.5"
+    external-editor "^2.1.0"
+    figures "^2.0.0"
     lodash "^4.3.0"
-    readline2 "^1.0.1"
-    run-async "^0.1.0"
-    rx-lite "^3.1.2"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rxjs "^5.5.2"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
     through "^2.3.6"
-
-interpret@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
 invariant@^2.2.2:
   version "2.2.4"
@@ -2292,6 +2379,10 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
+is-callable@^1.1.3, is-callable@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
+
 is-ci@^1.0.10, is-ci@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.2.1.tgz#e3779c8ee17fccf428488f6e281187f2e632841c"
@@ -2309,6 +2400,10 @@ is-data-descriptor@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
   dependencies:
     kind-of "^6.0.0"
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -2373,20 +2468,6 @@ is-installed-globally@^0.1.0:
     global-dirs "^0.1.0"
     is-path-inside "^1.0.0"
 
-is-my-ip-valid@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz#7b351b8e8edd4d3995d4d066680e664d94696824"
-
-is-my-json-valid@^2.10.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz#8fd6e40363cd06b963fa877d444bfb5eddc62175"
-  dependencies:
-    generate-function "^2.0.0"
-    generate-object-property "^1.1.0"
-    is-my-ip-valid "^1.0.0"
-    jsonpointer "^4.0.0"
-    xtend "^4.0.0"
-
 is-npm@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
@@ -2443,15 +2524,17 @@ is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
 
-is-property@^1.0.0, is-property@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
-
 is-redirect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
 
-is-resolvable@^1.0.0:
+is-regex@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  dependencies:
+    has "^1.0.1"
+
+is-resolvable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
 
@@ -2462,6 +2545,12 @@ is-retry-allowed@^1.0.0:
 is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+is-symbol@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.2.tgz#a055f6ae57192caee329e7a860118b497a950f38"
+  dependencies:
+    has-symbols "^1.0.0"
 
 is-url@^1.2.1:
   version "1.2.4"
@@ -2475,7 +2564,7 @@ is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
-isarray@1.0.0, isarray@~1.0.0:
+isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
@@ -2513,7 +2602,7 @@ js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.10.0, js-yaml@^3.5.1:
+js-yaml@^3.10.0, js-yaml@^3.11.0:
   version "3.12.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
   dependencies:
@@ -2532,23 +2621,23 @@ json-parse-better-errors@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
 
-json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
+
+json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
-  dependencies:
-    jsonify "~0.0.0"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
 json5@^0.5.0:
   version "0.5.1"
   resolved "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 
-jsonify@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
-
-jsonpointer@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
+jsx-ast-utils@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz#e801b1b39985e20fffc87b40e3748080e2dcac7f"
+  dependencies:
+    array-includes "^3.0.3"
 
 jwa@^1.1.5:
   version "1.1.6"
@@ -2597,6 +2686,15 @@ levn@^0.3.0, levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+load-json-file@^2.0.0:
+  version "2.0.0"
+  resolved "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    strip-bom "^3.0.0"
 
 load-json-file@^4.0.0:
   version "4.0.0"
@@ -2650,7 +2748,7 @@ lodash.merge@^4.6.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
 
-lodash@^4.0.0, lodash@^4.17.10, lodash@^4.3.0:
+lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
@@ -2660,7 +2758,7 @@ log-symbols@^2.2.0:
   dependencies:
     chalk "^2.0.1"
 
-loose-envify@^1.0.0:
+loose-envify@^1.0.0, loose-envify@^1.3.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
@@ -2794,7 +2892,7 @@ mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
 
-minimatch@^3.0.0, minimatch@^3.0.4:
+minimatch@^3.0.0, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -2811,7 +2909,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.2.0:
+minimist@^1.1.0, minimist@^1.2.0:
   version "1.2.0"
   resolved "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -2868,9 +2966,9 @@ multimatch@^2.1.0:
     arrify "^1.0.0"
     minimatch "^3.0.0"
 
-mute-stream@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
+mute-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
 mz@^2.7.0:
   version "2.7.0"
@@ -2916,9 +3014,9 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
-next-tick@1:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
+nice-try@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
 
 node-fetch@^2.2.0:
   version "2.2.0"
@@ -3026,7 +3124,7 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -3041,6 +3139,10 @@ object-copy@^0.1.0:
 object-hash@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-1.3.0.tgz#76d9ba6ff113cf8efc0d996102851fe6723963e2"
+
+object-keys@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -3077,10 +3179,6 @@ once@^1.3.0:
   dependencies:
     wrappy "1"
 
-onetime@^1.0.0:
-  version "1.1.0"
-  resolved "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
-
 onetime@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
@@ -3113,7 +3211,7 @@ os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
@@ -3174,6 +3272,12 @@ package-json@^4.0.0:
     registry-url "^3.0.3"
     semver "^5.1.0"
 
+parse-json@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
+  dependencies:
+    error-ex "^1.2.0"
+
 parse-json@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
@@ -3201,6 +3305,12 @@ path-dirname@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
 
+path-exists@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
+  dependencies:
+    pinkie-promise "^2.0.0"
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
@@ -3209,11 +3319,11 @@ path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
 
-path-is-inside@^1.0.1:
+path-is-inside@^1.0.1, path-is-inside@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
-path-key@^2.0.0:
+path-key@^2.0.0, path-key@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
@@ -3224,6 +3334,12 @@ path-parse@^1.0.5:
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+
+path-type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
+  dependencies:
+    pify "^2.0.0"
 
 path-type@^3.0.0:
   version "3.0.0"
@@ -3261,12 +3377,26 @@ pirates@^4.0.0:
   dependencies:
     node-modules-regexp "^1.0.0"
 
-pkg-conf@^2.1.0:
+pkg-conf@^2.0.0, pkg-conf@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/pkg-conf/-/pkg-conf-2.1.0.tgz#2126514ca6f2abfebd168596df18ba57867f0058"
   dependencies:
     find-up "^2.0.0"
     load-json-file "^4.0.0"
+
+pkg-config@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pkg-config/-/pkg-config-1.1.1.tgz#557ef22d73da3c8837107766c52eadabde298fe4"
+  dependencies:
+    debug-log "^1.0.0"
+    find-root "^1.0.0"
+    xtend "^4.0.1"
+
+pkg-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
+  dependencies:
+    find-up "^1.0.0"
 
 pkg-dir@^2.0.0:
   version "2.0.0"
@@ -3280,9 +3410,9 @@ plur@^3.0.1:
   dependencies:
     irregular-plurals "^2.0.0"
 
-pluralize@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-1.2.1.tgz#d1a21483fd22bb41e58a12fa3421823140897c45"
+pluralize@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -3310,9 +3440,16 @@ process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
-progress@^1.1.8:
-  version "1.1.8"
-  resolved "http://registry.npmjs.org/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
+progress@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.1.tgz#c9242169342b1c29d275889c95734621b1952e31"
+
+prop-types@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  dependencies:
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 proxy-addr@~2.0.4:
   version "2.0.4"
@@ -3336,6 +3473,10 @@ pstree.remy@^1.1.0:
   resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.0.tgz#f2af27265bd3e5b32bbfcc10e80bac55ba78688b"
   dependencies:
     ps-tree "^1.1.0"
+
+punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
 
 qs@6.5.2, qs@^6.5.2:
   version "6.5.2"
@@ -3371,12 +3512,27 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+read-pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
+  dependencies:
+    find-up "^2.0.0"
+    read-pkg "^2.0.0"
+
 read-pkg-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-3.0.0.tgz#3ed496685dba0f8fe118d0691dc51f4a1ff96f07"
   dependencies:
     find-up "^2.0.0"
     read-pkg "^3.0.0"
+
+read-pkg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8"
+  dependencies:
+    load-json-file "^2.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^2.0.0"
 
 read-pkg@^3.0.0:
   version "3.0.0"
@@ -3386,7 +3542,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.2.2:
+readable-stream@^2.0.2, readable-stream@^2.0.6:
   version "2.3.6"
   resolved "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   dependencies:
@@ -3405,20 +3561,6 @@ readdirp@^2.0.0:
     graceful-fs "^4.1.11"
     micromatch "^3.1.10"
     readable-stream "^2.0.2"
-
-readline2@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/readline2/-/readline2-1.0.1.tgz#41059608ffc154757b715d9989d199ffbf372e35"
-  dependencies:
-    code-point-at "^1.0.0"
-    is-fullwidth-code-point "^1.0.0"
-    mute-stream "0.0.5"
-
-rechoir@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
-  dependencies:
-    resolve "^1.1.6"
 
 redent@^2.0.0:
   version "2.0.0"
@@ -3453,6 +3595,10 @@ regex-not@^1.0.0, regex-not@^1.0.2:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
+
+regexpp@^2.0.0, regexpp@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
 
 regexpu-core@^4.1.3, regexpu-core@^4.2.0:
   version "4.2.0"
@@ -3510,7 +3656,7 @@ require-precompiled@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/require-precompiled/-/require-precompiled-0.1.0.tgz#5a1b52eb70ebed43eb982e974c85ab59571e56fa"
 
-require-uncached@^1.0.2:
+require-uncached@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
   dependencies:
@@ -3535,7 +3681,7 @@ resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
 
-resolve@^1.1.6, resolve@^1.3.2:
+resolve@^1.3.2, resolve@^1.5.0, resolve@^1.6.0, resolve@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:
@@ -3544,13 +3690,6 @@ resolve@^1.1.6, resolve@^1.3.2:
 resource-router-middleware@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/resource-router-middleware/-/resource-router-middleware-0.6.0.tgz#bccb286c22ae990840f963769c325f68c875c1f3"
-
-restore-cursor@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
-  dependencies:
-    exit-hook "^1.0.0"
-    onetime "^1.0.0"
 
 restore-cursor@^2.0.0:
   version "2.0.0"
@@ -3573,15 +3712,21 @@ rimraf@^2.2.8, rimraf@^2.6.1:
   dependencies:
     glob "^7.0.5"
 
-run-async@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
+run-async@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
   dependencies:
-    once "^1.3.0"
+    is-promise "^2.1.0"
 
-rx-lite@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
+run-parallel@^1.1.2:
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.1.9.tgz#c9dd3a7cf9f4b2c4b6244e173a6ed866e61dd679"
+
+rxjs@^5.5.2:
+  version "5.5.12"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.12.tgz#6fa61b8a77c3d793dbaf270bee2f43f652d741cc"
+  dependencies:
+    symbol-observable "1.0.1"
 
 safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
@@ -3678,14 +3823,6 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shelljs@^0.7.5:
-  version "0.7.8"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.8.tgz#decbcf874b0d1e5fb72e14b164a9683048e9acb3"
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
-
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -3698,11 +3835,7 @@ slash@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
 
-slice-ansi@0.0.4:
-  version "0.0.4"
-  resolved "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
-
-slice-ansi@^1.0.0:
+slice-ansi@1.0.0, slice-ansi@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
   dependencies:
@@ -3810,6 +3943,29 @@ stack-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
 
+standard-engine@~9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/standard-engine/-/standard-engine-9.0.0.tgz#d3a3d74c4c1b91f51a1e66362465261ca7610316"
+  dependencies:
+    deglob "^2.1.0"
+    get-stdin "^6.0.0"
+    minimist "^1.1.0"
+    pkg-conf "^2.0.0"
+
+standard@^12.0.1:
+  version "12.0.1"
+  resolved "https://registry.yarnpkg.com/standard/-/standard-12.0.1.tgz#0fc5a8aa6c34c546c5562aae644242b24dae2e61"
+  dependencies:
+    eslint "~5.4.0"
+    eslint-config-standard "12.0.0"
+    eslint-config-standard-jsx "6.0.2"
+    eslint-plugin-import "~2.14.0"
+    eslint-plugin-node "~7.0.1"
+    eslint-plugin-promise "~4.0.0"
+    eslint-plugin-react "~7.11.1"
+    eslint-plugin-standard "~4.0.0"
+    standard-engine "~9.0.0"
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -3840,7 +3996,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.1:
+"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
@@ -3883,7 +4039,7 @@ strip-indent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
-strip-json-comments@~2.0.1:
+strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
@@ -3907,6 +4063,10 @@ supports-color@^5.2.0, supports-color@^5.3.0, supports-color@^5.5.0:
   dependencies:
     has-flag "^3.0.0"
 
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
+
 symbol-observable@^0.2.2:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-0.2.4.tgz#95a83db26186d6af7e7a18dbd9760a2f86d08f40"
@@ -3915,16 +4075,16 @@ symbol-observable@^1.0.4, symbol-observable@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 
-table@^3.7.8:
-  version "3.8.3"
-  resolved "http://registry.npmjs.org/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
+table@^4.0.3:
+  version "4.0.3"
+  resolved "http://registry.npmjs.org/table/-/table-4.0.3.tgz#00b5e2b602f1794b9acaf9ca908a76386a7813bc"
   dependencies:
-    ajv "^4.7.0"
-    ajv-keywords "^1.0.0"
-    chalk "^1.1.1"
-    lodash "^4.0.0"
-    slice-ansi "0.0.4"
-    string-width "^2.0.0"
+    ajv "^6.0.1"
+    ajv-keywords "^3.0.0"
+    chalk "^2.1.0"
+    lodash "^4.17.4"
+    slice-ansi "1.0.0"
+    string-width "^2.1.1"
 
 tar@^4:
   version "4.4.6"
@@ -3944,7 +4104,7 @@ term-size@^1.2.0:
   dependencies:
     execa "^0.7.0"
 
-text-table@~0.2.0:
+text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 
@@ -3971,6 +4131,12 @@ time-zone@^1.0.0:
 timed-out@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
+
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  dependencies:
+    os-tmpdir "~1.0.2"
 
 to-fast-properties@^2.0.0:
   version "2.0.0"
@@ -4033,10 +4199,6 @@ type-is@~1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.18"
 
-typedarray@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
-
 uid2@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/uid2/-/uid2-0.0.3.tgz#483126e11774df2f71b8b639dcd799c376162b82"
@@ -4074,6 +4236,10 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^0.4.3"
+
+uniq@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
 
 unique-string@^1.0.0:
   version "1.0.0"
@@ -4123,6 +4289,12 @@ update-notifier@^2.3.0, update-notifier@^2.5.0:
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
 
+uri-js@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
+  dependencies:
+    punycode "^2.1.0"
+
 urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
@@ -4140,12 +4312,6 @@ url-template@^2.0.8:
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
-
-user-home@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
-  dependencies:
-    os-homedir "^1.0.0"
 
 util-deprecate@~1.0.1:
   version "1.0.2"
@@ -4230,7 +4396,7 @@ xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
 
-xtend@^4.0.0:
+xtend@^4.0.0, xtend@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
Continuation of [Topic/add travis build test](https://github.com/forensic-architecture/datasheet-server/pull/11). @scztt, I've made a couple of changes:

1. added inline comments to the somewhat confusing need for explicit imports in lib/blueprinters. It's actually a mix of ES5/ES6 export syntax, which is why it is somewhat unintuitive. There's a bit of hacky Node import logic to enable clean and granular imports of all files in the blueprints folder from [config.js](https://github.com/forensic-architecture/datasheet-server/blob/develop/src/example.config.js#L1). There probably is a cleaner way using just ES6....
2. I changed ESLint to Standard, which I prefer as a linter just because it is simpler in package.json.
~3. Added linting for tests, as well as a server_process test.~
 