### PR TITLE
Fix/ids retrieve frag docs

### DIFF
--- a/src/blueprinters/ids.js
+++ b/src/blueprinters/ids.js
@@ -32,11 +32,12 @@ export default function ids (
   const itemLabels = data[0]
   const fmt = fmtObj(itemLabels)
   bp.resources[label] = R.clone(defaultResource)
-  bp.resources[label].data = []
+  bp.resources[label].data = {}
 
   data.forEach((row, idx) => {
     if (idx === 0) return
     bp.resources[label].data[fmt(row).id] = fmt(row)
   })
+
   return bp
 }

--- a/src/copy/en.js
+++ b/src/copy/en.js
@@ -5,7 +5,8 @@ export default {
     onlyTab: 'You cannot query a tab directly. The URL needs to be in the format /:sheet/:tab/:resource.',
     noSheet: sheet => `The sheet ${sheet} is not available in this server.`,
     noResource: prts => `The resource '${prts[2]}' does not exists in the tab '${prts[1]}' in this sheet.`,
-    noFragment: prts => `Fragment index does not exist`
+    noFragment: prts => `Fragment index does not exist`,
+    modelLayer: prts => `Something went wrong at the model layer`
   },
   success: {
     update: 'All sheets updated'

--- a/src/lib/Fetcher.js
+++ b/src/lib/Fetcher.js
@@ -189,7 +189,7 @@ class Fetcher {
 
   retrieveFrag (tab, resource, frag) {
     const title = fmtName(tab)
-    const url = `${this.sheetName}/${tab}/${resource}/${frag}`
+    const url = `${this.id}/${tab}/${resource}/${frag}`
     return this.db.load(url, this.blueprints[title])
   }
 }

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -11,3 +11,9 @@ export function noFragment (parts) {
 export function noResource (parts) {
   return new Error(copy.errors.noResource(parts))
 }
+
+export default {
+  modelLayerGeneric,
+  noFragment,
+  noResource
+}

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -1,0 +1,13 @@
+import copy from '../copy/en'
+
+export function modelLayerGeneric (parts) {
+  return new Error(copy.errors.modelLayer(parts))
+}
+
+export function noFragment (parts) {
+  return new Error(copy.errors.noFragment(parts))
+}
+
+export function noResource (parts) {
+  return new Error(copy.errors.noResource(parts))
+}

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -37,7 +37,8 @@ export const fmtObj = R.curry(
       }
     }
     columnNames.forEach((columnName, idx) => {
-      obj[fmtColName(columnName)] = row[idx]
+      const value = row[idx] ? row[idx] : ""
+      obj[fmtColName(columnName)] = value
     })
     return obj
   }

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -37,7 +37,7 @@ export const fmtObj = R.curry(
       }
     }
     columnNames.forEach((columnName, idx) => {
-      const value = row[idx] ? row[idx] : ""
+      const value = row[idx] ? row[idx] : ''
       obj[fmtColName(columnName)] = value
     })
     return obj

--- a/src/models/Interface.js
+++ b/src/models/Interface.js
@@ -1,30 +1,41 @@
 /* eslint-disable */
 /**
- * Model is a class whose sole responsibility is to save and load blueprints.
- * It allows for different storage mechanisms for different kinds of blueprints.
+ * Model is a class whose sole responsibility is to save and load data through a custom URL format.
+ * As an interfacce, it allows for different storage mechanisms, and different scale/performance for different kinds of data.
  * 
  * ERRORS:
  * When a load function fails, it should throw either:
- * 1. A __ error if the resource doesn't exist on that sheet/tab.
- * 2. A __ error if a fragment lookup fails because it doesn't exist.
- * 3. A __ error if something else goes wrong.
+ * 1. noResource(parts) if the resource doesn't exist on that sheet/tab.
+ * 2. noFragment(parts) if a fragment lookup fails because it doesn't exist.
+ * 3. modelLayerGeneric(parts) if something else goes wrong.
+ *
+ * This is a WIP layer. See StoreJson.js for an example in action.
  */
 class Model {
   /**
-   * save - save a Blueprint, using the information it contains.
-   *
-   * @param  {type} blueprint the Blueprint to be saved.
-   * @return {type} Promise   which returns True.
+   * Index the data stored by this model, returning a list of the available URLs. 
+   * @return {Promise(boolean)} Unpacks to a list of available URLs if successful, throws an error otherwise.
    */
-  save (blueprint) {}
+  index () {}
+  
+  /**
+   * Save data at a URL. The URL is in the format
+   *    /:fetcherID/:tab/:resource
+   * Fetcher IDs must be unique, tabs and resources can be duplicated across
+   * different fetchers.
+   * 
+   * @param  {string} url - the URL at which to save the data.
+   * @param  {object} data - the data to be saved.
+   * @return {Promise(boolean)} Unpacks to true if the update was successful, false if otherwise.
+   */
+  save (url, data) {}
 
   /**
-   * load - load a resource from a data model, using a Blueprint object as
-   * well as a REST-like  URL of the format /:source/:tab/:resource.
-   *
-   * @param  {type} url       String that represents the path to resource.
-   * @param  {type} blueprint Blueprint object (desaturated?).
-   * @return {type}           Object containing the resource data.
+   * Load data from a URL, in the format
+   *    /:fetcherID/:tab/:resource
+   * 
+   * @param  {string} url - the URL at which to load the data.
+   * @return {Promise(object)} a Promise that unpacks to the data retrieved. An error will be thrown if the URL is invalid.
    */
-  load (url, blueprint) {}
+  load (url) {}
 }

--- a/src/models/StoreJson.js
+++ b/src/models/StoreJson.js
@@ -1,5 +1,5 @@
 import fs from 'mz/fs'
-import copy from '../copy/en'
+import errors from '../lib/errors'
 
 const STORAGE_DIRNAME = 'temp'
 
@@ -45,7 +45,7 @@ class StoreJson {
             if (!isNaN(id) && id >= 0 && id < data.length) {
               return data[id]
             } else {
-              throw new Error(copy.errors.noFragment(parts))
+              throw errors.noFragment(parts)
             }
           } else {
             // Do a lookup if fragment is included to filter a relevant item
@@ -53,12 +53,12 @@ class StoreJson {
             if (!isNaN(index) && index >= 0 && index < data.length) {
               return data.filter((vl, idx) => idx === index)[0]
             } else {
-              throw new Error(copy.errors.noFragment(parts))
+              throw errors.noFragment(parts)
             }
           }
         })
     } else {
-      return Promise.reject(new Error(copy.errors.noResource(parts)))
+      return Promise.reject(errors.noResource(parts))
     }
   }
 


### PR DESCRIPTION
closes #20 

This fixes a few bugs that must have been swept under the rug in the heyday of 0.1.0 release.
* the `retreiveFrag` function is updated to reference to new unique ID for sheets
* the `ids` blueprinter was storing an empty array due to a faulty blueprinter function

I've also documented better the the interface for the model layer, and made a step towards standardising errors by exporting them from a single file.