### PR TITLE
Fixed internal anchor link headline

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Each Google Sheet being used as a as source requires a corresponding object in `
 See src/config.js for an example configuration sheet. 
 
 
-## [Quickstart](#quickstart)
+## [Quickstart](#quickstart)
 Clone the repository to your local:
 ```
 git clone https://www.github.com/forensic-architecture/datasheet-server


### PR DESCRIPTION
The internal link on top of the readme did not work anymore because for some reason the ## Quickstart headline was broken. Maybe weird space character? Furthermore the #configuration anchor-link leads to nowhere.