### PR TITLE
Feature/refactor categories

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import http from 'http'
+import path from 'path'
 import express from 'express'
 import initialize from './initialize'
 import middleware from './middleware'
@@ -40,7 +41,7 @@ initialize(controller => {
     })
   )
 
-  app.use(express.static(__dirname + '/public'))
+  app.use(express.static(path.join(__dirname, 'public')))
 
   app.server.listen(process.env.PORT || 4040, () => {
     console.log('===========================================')

--- a/src/lib.js
+++ b/src/lib.js
@@ -4,8 +4,7 @@ function prefixedTabs (prefix, cfg) {
   if (!cfg) cfg = {}
   const prf = key => cfg[key] ? `${prefix}_` : ''
   return {
-    // [`${prf('events')}export_events`]: BP.deeprows,
-    [`test_export_events`]: BP.deeprows,
+    [`${prf('events')}export_events`]: BP.deeprows,
     [`${prf('associations')}export_associations`]: BP.deeprows,
     [`${prf('sources')}export_sources`]: BP.deepids,
     [`${prf('sites')}export_sites`]: BP.rows

--- a/src/lib.js
+++ b/src/lib.js
@@ -4,7 +4,8 @@ function prefixedTabs (prefix, cfg) {
   if (!cfg) cfg = {}
   const prf = key => cfg[key] ? `${prefix}_` : ''
   return {
-    [`${prf('events')}export_events`]: BP.deeprows,
+    // [`${prf('events')}export_events`]: BP.deeprows,
+    [`test_export_events`]: BP.deeprows,
     // [`${prf('categories')}export_categories`]: [BP.groups, BP.rows],
     [`${prf('associations')}export_associations`]: BP.deeprows,
     [`${prf('sources')}export_sources`]: BP.deepids,

--- a/src/lib.js
+++ b/src/lib.js
@@ -7,7 +7,8 @@ function prefixedTabs (prefix, cfg) {
     // [`${prf('events')}export_events`]: BP.deeprows,
     [`test_export_events`]: BP.deeprows,
     // [`${prf('categories')}export_categories`]: [BP.groups, BP.rows],
-    [`${prf('associations')}export_associations`]: BP.deeprows,
+    // [`${prf('associations')}export_associations`]: BP.deeprows,
+    [`test_export_associations`]: BP.deeprows,
     [`${prf('sources')}export_sources`]: BP.deepids,
     [`${prf('sites')}export_sites`]: BP.rows
   }

--- a/src/lib.js
+++ b/src/lib.js
@@ -5,7 +5,7 @@ function prefixedTabs (prefix, cfg) {
   const prf = key => cfg[key] ? `${prefix}_` : ''
   return {
     [`${prf('events')}export_events`]: BP.deeprows,
-    [`${prf('categories')}export_categories`]: [BP.groups, BP.rows],
+    // [`${prf('categories')}export_categories`]: [BP.groups, BP.rows],
     [`${prf('associations')}export_associations`]: BP.deeprows,
     [`${prf('sources')}export_sources`]: BP.deepids,
     [`${prf('sites')}export_sites`]: BP.rows

--- a/src/lib.js
+++ b/src/lib.js
@@ -6,9 +6,7 @@ function prefixedTabs (prefix, cfg) {
   return {
     // [`${prf('events')}export_events`]: BP.deeprows,
     [`test_export_events`]: BP.deeprows,
-    // [`${prf('categories')}export_categories`]: [BP.groups, BP.rows],
-    // [`${prf('associations')}export_associations`]: BP.deeprows,
-    [`test_export_associations`]: BP.deeprows,
+    [`${prf('associations')}export_associations`]: BP.deeprows,
     [`${prf('sources')}export_sources`]: BP.deepids,
     [`${prf('sites')}export_sites`]: BP.rows
   }


### PR DESCRIPTION
Removes `export_categories` endpoint because [Timemap PR](https://github.com/forensic-architecture/timemap/pull/163)
understands categories to be associations, not standalone data structures.