### PR TITLE
Updating dockerfile port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN yarn build
 RUN mkdir -p data
 
 # set your port
-ENV PORT 8080
-EXPOSE  8080
+ENV PORT 4040
+EXPOSE  4040
 
 # start command as per package.json
 CMD ["yarn", "start"]


### PR DESCRIPTION
Docker port in container when deployed through ansible playbook script gets overwritten with port 4040. Setting this as the default port exposed in the container to account for this issue.