### PR TITLE
Adding export_shapes endpoint

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -7,6 +7,7 @@ function prefixedTabs (prefix, cfg) {
     [`${prf('events')}export_events`]: BP.deeprows,
     [`${prf('associations')}export_associations`]: BP.deeprows,
     [`${prf('sources')}export_sources`]: BP.deepids,
+    [`${prf('shapes')}export_shapes`]: BP.deeprows,
     [`${prf('sites')}export_sites`]: BP.rows
   }
 }


### PR DESCRIPTION
Adds an `export_shapes` endpoint.

[Frontend PR](https://github.com/forensic-architecture/timemap/pull/210)